### PR TITLE
Changes to complete #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,10 @@ ISSUER_URL=http://localhost:3213/api
 # KEY STORAGE CONFIG
 KEY_STORAGE_STRONGHOLD_SNAPSHOT_PATH="./key_storage.stronghold" # file path where secrets will be stored
 KEY_STORAGE_STRONGHOLD_PASSWORD="some_hopefully_secure_password" # password used for Stronghold file encryption
-KEY_STORAGE_MNEMONIC="grace eye hour away retire put crunch burger bracket coyote twist cherry glare collect retreat" # mnemonic seed for key storage generation
 
 ## WALLET CONFIG
 WALLET_STRONGHOLD_SNAPSHOT_PATH="./wallet.stronghold" # file path where wallet keys will be stored
 WALLET_STRONGHOLD_PASSWORD="some_hopefully_secure_password" # password used for Stronghold file encryption
-WALLET_MNEMONIC="grace eye hour away retire put crunch burger bracket coyote twist cherry glare collect retreat" # mnemonic seed for wallet generation
 
 # DATABASE CONNECTION CONFIG
 DB_USER="postgres"

--- a/README.md
+++ b/README.md
@@ -70,9 +70,20 @@ A Docker compose file has been set for deploying. A Postgres database and the ap
 ```bash
 docker compose --profile deploy up -d
 ```
+Remember to properly configure [environnment variables](#environment-setup)  before running the command.
 
-Remember to configure environnment variables properly before running the command.
+#### Backup and restore
+Generated keys are stored in files generated for key storage and wallet. They're both saved in `/data` inside the container. Those files are protected with the passwords provided in the [environnment variables](#environment-setup). The data folder needs to be syncronized with postgres data as well.
 
+##### Backup operation
+- Copy the container `/data` folder into a different storage
+- Store the passwords securely
+- Backup Postgres
+
+##### Restore operation
+- Copy back into the `/data` folder
+- Set corresponding passwords in the environnment variable
+- Restore Postgres backup
 
 ## Dev Utils
 - [OpenAPI spec](/api/dlt_booth.yaml)

--- a/dlt-booth/env/example.env
+++ b/dlt-booth/env/example.env
@@ -18,12 +18,10 @@ ISSUER_URL=http://localhost:3213/api
 # KEY STORAGE CONFIG
 KEY_STORAGE_STRONGHOLD_SNAPSHOT_PATH="./key_storage.stronghold"
 KEY_STORAGE_STRONGHOLD_PASSWORD="some_hopefully_secure_password"
-KEY_STORAGE_MNEMONIC="grace eye hour away retire put crunch burger bracket coyote twist cherry glare collect retreat"
 
 # WALLET CONFIG
 WALLET_STRONGHOLD_SNAPSHOT_PATH="./wallet.stronghold" # file path where wallet keys will be stored
 WALLET_STRONGHOLD_PASSWORD="some_hopefully_secure_password" # password used for Stronghold file encryption
-WALLET_MNEMONIC="grace eye hour away retire put crunch burger bracket coyote twist cherry glare collect retreat"
 
 # DATABASE CONNECTION CONFIG
 DB_USER="postgres"

--- a/dlt-booth/src/utils/configs.rs
+++ b/dlt-booth/src/utils/configs.rs
@@ -40,9 +40,6 @@ pub struct KeyStorageConfig {
     /// Secrets that unlocks the KeyStorage
     #[arg(id = "KEY_STORAGE_STRONGHOLD_PASSWORD", long, env, required = true)]
     pub password: ConfigSecret,
-    /// Mnemonic seed to be stored inside the KeyStorage
-    #[arg(id = "KEY_STORAGE_MNEMONIC", long, env, required = true)]
-    pub mnemonic: ConfigSecret,
 }
 
 /// Configuration parameters for the key storage
@@ -59,9 +56,6 @@ pub struct WalletStorageConfig {
     /// Secrets that unlocks the KeyStorage
     #[arg(id = "WALLET_STRONGHOLD_PASSWORD", long, env, required = true)]
     pub password: ConfigSecret,
-    /// Mnemonic seed to be stored inside the KeyStorage
-    #[arg(id = "WALLET_MNEMONIC", long, env, required = true)]
-    pub mnemonic: ConfigSecret,
 }
 
 /// Configuration parameters for the issuer database

--- a/dlt-booth/src/utils/iota.rs
+++ b/dlt-booth/src/utils/iota.rs
@@ -109,7 +109,7 @@ impl IotaState {
     let mnemonic_clone = mnemonic.clone();
 
     match stronghold.store_mnemonic(mnemonic).await {
-      Ok(())=> log::info!("Stronghold mnemonic stored (Key storage):\n{}", mnemonic_clone.as_ref()),
+      Ok(())=> log::info!("Stronghold mnemonic stored (Key storage)"),
       Err(iota_sdk::client::stronghold::Error::MnemonicAlreadyStored) => log::debug!("Stronghold mnemonic already stored (Key storage)"),
       Err(error) => panic!("Error: {:?}", error)
     }
@@ -139,7 +139,7 @@ impl IotaState {
     let wallet_mnemonic_clone = wallet_mnemonic.clone();
 
     match wallet_stronghold.store_mnemonic(wallet_mnemonic).await{
-      Ok(()) => log::info!("Stronghold mnemonic stored (Wallet):\n{}", wallet_mnemonic_clone.as_ref()),
+      Ok(()) => log::info!("Stronghold mnemonic stored (Wallet)"),
       Err(iota_sdk::client::stronghold::Error::MnemonicAlreadyStored) => log::debug!("Stronghold mnemonic already stored (Wallet)"),
       Err(error) => panic!("Error: {:?}", error)      
     }


### PR DESCRIPTION
Closes #14.

Mnemonics are now generated within the DLT Booth and printed on info only when the Stronghold files need to be generated. Old environments parameters have been removed.
